### PR TITLE
[MB-13103] fix virus database update failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,63 +11,45 @@ COPY ./*.py /opt/app/
 COPY requirements.txt /opt/app/requirements.txt
 
 # Install packages
-RUN yum update -y
-RUN amazon-linux-extras install epel -y
-RUN yum install -y cpio yum-utils tar.x86_64 gzip zip python3-pip
-
-# This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
-RUN pip3 install -r requirements.txt
-RUN rm -rf /root/.cache/pip
+RUN yum update -y && \
+    amazon-linux-extras install epel -y && \
+    yum install -y cpio yum-utils tar.x86_64 gzip zip python3-pip shadow-utils.x86_64 && \
+    pip3 install -r requirements.txt && \
+    rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav
-RUN rpm2cpio clamav-0*.rpm | cpio -vimd
+RUN yumdownloader -x \*i686 --archlist=x86_64 \
+        clamav clamav-lib clamav-update json-c \
+        pcre2 libtool-ltdl libxml2 bzip2-libs \
+        xz-libs libprelude gnutls nettle
 
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav-lib
-RUN rpm2cpio clamav-lib*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav-update
-RUN rpm2cpio clamav-update*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 json-c
-RUN rpm2cpio json-c*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 pcre2
-RUN rpm2cpio pcre*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 libtool-ltdl
-RUN rpm2cpio libtool-ltdl*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 libxml2
-RUN rpm2cpio libxml2*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 bzip2-libs
-RUN rpm2cpio bzip2-libs*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 xz-libs
-RUN rpm2cpio xz-libs*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 libprelude
-RUN rpm2cpio libprelude*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 gnutls
-RUN rpm2cpio gnutls*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 nettle
-RUN rpm2cpio nettle*.rpm | cpio -vimd
+RUN rpm2cpio clamav-0*.rpm | cpio -vimd && \
+    rpm2cpio clamav-lib*.rpm | cpio -vimd && \
+    rpm2cpio clamav-update*.rpm | cpio -vimd && \
+    rpm2cpio json-c*.rpm | cpio -vimd && \
+    rpm2cpio pcre*.rpm | cpio -vimd && \
+    rpm2cpio libtool-ltdl*.rpm | cpio -vimd && \
+    rpm2cpio libxml2*.rpm | cpio -vimd && \
+    rpm2cpio bzip2-libs*.rpm | cpio -vimd && \
+    rpm2cpio xz-libs*.rpm | cpio -vimd && \
+    rpm2cpio libprelude*.rpm | cpio -vimd && \
+    rpm2cpio gnutls*.rpm | cpio -vimd && \
+    rpm2cpio nettle*.rpm | cpio -vimd
 
 
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /opt/app/bin/
+RUN cp /tmp/usr/bin/clamscan \
+       /tmp/usr/bin/freshclam \
+       /tmp/usr/lib64/* \
+       /usr/lib64/libpcre.so.1 \
+       /opt/app/bin/
 
 # Fix the freshclam.conf settings
-RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf
-RUN echo "CompressLocalDatabase yes" >> /opt/app/bin/freshclam.conf
-RUN echo "ScriptedUpdates no" >> /opt/app/bin/freshclam.conf
-RUN echo "DatabaseDirectory /var/lib/clamav" >> /opt/app/bin/freshclam.conf
-
-RUN yum install shadow-utils.x86_64 -y
+RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf && \
+    echo "CompressLocalDatabase yes" >> /opt/app/bin/freshclam.conf && \
+    echo "ScriptedUpdates no" >> /opt/app/bin/freshclam.conf && \
+    echo "DatabaseDirectory /var/lib/clamav" >> /opt/app/bin/freshclam.conf
 
 RUN groupadd clamav
 RUN useradd -g clamav -s /bin/false -c "Clam Antivirus" clamav

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,13 @@ RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle
+RUN yumdownloader -x \*i686 --archlist=x86_64 json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle && \
+    wget \
+        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/x86_64/clamav-0.102.3-1.el7.x86_64.rpm \
+        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/x86_64/clamav-lib-0.102.3-1.el7.x86_64.rpm \
+        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/x86_64/clamav-update-0.102.3-1.el7.x86_64.rpm \
+        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/noarch/clamav-filesystem-0.102.3-1.el7.noarch.rpm \
+    ;
 RUN rpm2cpio clamav-0*.rpm | cpio -idmv
 RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
 RUN rpm2cpio clamav-update*.rpm | cpio -idmv

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY requirements.txt /opt/app/requirements.txt
 
 # Install packages
 RUN yum update -y
-RUN yum install -y cpio python3-pip yum-utils zip unzip less
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN amazon-linux-extras install epel -y
+RUN yum install -y cpio yum-utils tar.x86_64 gzip zip python3-pip
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
 RUN pip3 install -r requirements.txt
@@ -21,30 +21,60 @@ RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle && \
-    wget \
-        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/x86_64/clamav-0.102.3-1.el7.x86_64.rpm \
-        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/x86_64/clamav-lib-0.102.3-1.el7.x86_64.rpm \
-        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/x86_64/clamav-update-0.102.3-1.el7.x86_64.rpm \
-        https://kojipkgs.fedoraproject.org//packages/clamav/0.102.3/1.el7/noarch/clamav-filesystem-0.102.3-1.el7.noarch.rpm \
-    ;
-RUN rpm2cpio clamav-0*.rpm | cpio -idmv
-RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
-RUN rpm2cpio clamav-update*.rpm | cpio -idmv
-RUN rpm2cpio json-c*.rpm | cpio -idmv
-RUN rpm2cpio pcre*.rpm | cpio -idmv
-RUN rpm2cpio gnutls* | cpio -idmv
-RUN rpm2cpio nettle* | cpio -idmv
-RUN rpm2cpio lib* | cpio -idmv
-RUN rpm2cpio *.rpm | cpio -idmv
-RUN rpm2cpio libtasn1* | cpio -idmv
+RUN yumdownloader -x \*i686 --archlist=x86_64 clamav
+RUN rpm2cpio clamav-0*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 clamav-lib
+RUN rpm2cpio clamav-lib*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 clamav-update
+RUN rpm2cpio clamav-update*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 json-c
+RUN rpm2cpio json-c*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 pcre2
+RUN rpm2cpio pcre*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 libtool-ltdl
+RUN rpm2cpio libtool-ltdl*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 libxml2
+RUN rpm2cpio libxml2*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 bzip2-libs
+RUN rpm2cpio bzip2-libs*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 xz-libs
+RUN rpm2cpio xz-libs*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 libprelude
+RUN rpm2cpio libprelude*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 gnutls
+RUN rpm2cpio gnutls*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 nettle
+RUN rpm2cpio nettle*.rpm | cpio -vimd
+
 
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /opt/app/bin/
+RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf
 RUN echo "CompressLocalDatabase yes" >> /opt/app/bin/freshclam.conf
+RUN echo "ScriptedUpdates no" >> /opt/app/bin/freshclam.conf
+RUN echo "DatabaseDirectory /var/lib/clamav" >> /opt/app/bin/freshclam.conf
+
+RUN yum install shadow-utils.x86_64 -y
+
+RUN groupadd clamav
+RUN useradd -g clamav -s /bin/false -c "Clam Antivirus" clamav
+RUN useradd -g clamav -s /bin/false -c "Clam Antivirus" clamupdate
+
+ENV LD_LIBRARY_PATH=/opt/app/bin
+RUN ldconfig
 
 # Create the zip file
 WORKDIR /opt/app

--- a/clamav.py
+++ b/clamav.py
@@ -81,6 +81,7 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
         for file_suffix in AV_DEFINITION_FILE_SUFFIXES:
             filename = file_prefix + "." + file_suffix
             local_file_path = os.path.join(local_path, filename)
+            print("local_file_path = %s" % local_file_path)
             if os.path.exists(local_file_path):
                 local_file_md5 = md5_from_file(local_file_path)
                 if local_file_md5 != md5_from_s3_tags(

--- a/clamav.py
+++ b/clamav.py
@@ -81,7 +81,6 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
         for file_suffix in AV_DEFINITION_FILE_SUFFIXES:
             filename = file_prefix + "." + file_suffix
             local_file_path = os.path.join(local_path, filename)
-            print("local_file_path = %s" % local_file_path)
             if os.path.exists(local_file_path):
                 local_file_md5 = md5_from_file(local_file_path)
                 if local_file_md5 != md5_from_s3_tags(


### PR DESCRIPTION
Dockerfile edited to match this comment: https://github.com/bluesentry/bucket-antivirus-function/issues/202#issuecomment-1194397587

Fixes the issue where the virus database was not updating.

Also consolidates some of the download layers

Ignore the branch name which suggests a python3.8 upgrade - that will be a separate PR while I figure that out