### PR TITLE
[MB-15807] pass extra arguments to specify encryption type 

### DIFF
--- a/clamav.py
+++ b/clamav.py
@@ -92,7 +92,9 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path, extra_args):
                     )
                     s3 = boto3.resource("s3", endpoint_url=S3_ENDPOINT)
                     s3_object = s3.Object(bucket, os.path.join(prefix, filename))
-                    s3_object.upload_file(os.path.join(local_path, filename), ExtraArgs=extra_args)
+                    s3_object.upload_file(
+                        os.path.join(local_path, filename), ExtraArgs=extra_args
+                    )
                     s3_client.put_object_tagging(
                         Bucket=s3_object.bucket_name,
                         Key=s3_object.key,

--- a/clamav.py
+++ b/clamav.py
@@ -76,7 +76,7 @@ def update_defs_from_s3(s3_client, bucket, prefix):
     return to_download
 
 
-def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
+def upload_defs_to_s3(s3_client, bucket, prefix, local_path, extra_args):
     for file_prefix in AV_DEFINITION_FILE_PREFIXES:
         for file_suffix in AV_DEFINITION_FILE_SUFFIXES:
             filename = file_prefix + "." + file_suffix
@@ -92,7 +92,7 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
                     )
                     s3 = boto3.resource("s3", endpoint_url=S3_ENDPOINT)
                     s3_object = s3.Object(bucket, os.path.join(prefix, filename))
-                    s3_object.upload_file(os.path.join(local_path, filename))
+                    s3_object.upload_file(os.path.join(local_path, filename), ExtraArgs=extra_args)
                     s3_client.put_object_tagging(
                         Bucket=s3_object.bucket_name,
                         Key=s3_object.key,

--- a/update.py
+++ b/update.py
@@ -51,5 +51,11 @@ def lambda_handler(event, context):
         if os.path.exists(os.path.join(AV_DEFINITION_PATH, "main.cvd")):
             os.remove(os.path.join(AV_DEFINITION_PATH, "main.cvd"))
         clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
-    clamav.upload_defs_to_s3(s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX, AV_DEFINITION_PATH, extra_args={'ServerSideEncryption': 'AES256'})
+    clamav.upload_defs_to_s3(
+        s3_client,
+        AV_DEFINITION_S3_BUCKET,
+        AV_DEFINITION_S3_PREFIX,
+        AV_DEFINITION_PATH,
+        extra_args={"ServerSideEncryption": "AES256"},
+    )
     print("Script finished at %s\n" % get_timestamp())

--- a/update.py
+++ b/update.py
@@ -51,7 +51,5 @@ def lambda_handler(event, context):
         if os.path.exists(os.path.join(AV_DEFINITION_PATH, "main.cvd")):
             os.remove(os.path.join(AV_DEFINITION_PATH, "main.cvd"))
         clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
-    clamav.upload_defs_to_s3(
-        s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX, AV_DEFINITION_PATH
-    )
+    clamav.upload_defs_to_s3(s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX, AV_DEFINITION_PATH, extra_args={'ServerSideEncryption': 'AES256'})
     print("Script finished at %s\n" % get_timestamp())


### PR DESCRIPTION
Since S3 no longer allows unencrypted buckets and defaults to AES256 encryption, the upload function was not working since no `ExtraArgs` specifying this were being passed.

Note: in the future we should make it so a user can specify AES256 or a specific CMK. cc @trussworks/waddlers if you'd like to add this to your board!