### PR TITLE
[MB-16059] get rid of the s3 object version id from the delivered sns message

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -180,7 +180,6 @@ def sns_scan_results(
     message = {
         "bucket": s3_object.bucket_name,
         "key": s3_object.key,
-        "version": s3_object.version_id,
         AV_SIGNATURE_METADATA: scan_signature,
         AV_STATUS_METADATA: scan_result,
         AV_TIMESTAMP_METADATA: get_timestamp(),

--- a/scan_test.py
+++ b/scan_test.py
@@ -371,7 +371,6 @@ class TestScan(unittest.TestCase):
         message = {
             "bucket": self.s3_bucket_name,
             "key": self.s3_key_name,
-            "version": version_id,
             AV_SIGNATURE_METADATA: scan_signature,
             AV_STATUS_METADATA: scan_result,
             AV_TIMESTAMP_METADATA: timestamp,


### PR DESCRIPTION
## [Trello Card Title](URL)

Changes proposed in this pull request:

- Change 1
- Change 2
