### PR TITLE
Add flag to skip clean objects

### DIFF
--- a/common.py
+++ b/common.py
@@ -43,6 +43,7 @@ AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
 
 AV_DEFINITION_FILE_PREFIXES = ["main", "daily", "bytecode"]
 AV_DEFINITION_FILE_SUFFIXES = ["cld", "cvd"]
+AV_SKIP_CLEAN_OBJECTS = os.getenv("AV_SKIP_CLEAN_OBJECTS", "False")
 SNS_ENDPOINT = os.getenv("SNS_ENDPOINT", None)
 S3_ENDPOINT = os.getenv("S3_ENDPOINT", None)
 LAMBDA_ENDPOINT = os.getenv("LAMBDA_ENDPOINT", None)

--- a/common.py
+++ b/common.py
@@ -43,7 +43,7 @@ AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
 
 AV_DEFINITION_FILE_PREFIXES = ["main", "daily", "bytecode"]
 AV_DEFINITION_FILE_SUFFIXES = ["cld", "cvd"]
-AV_SKIP_CLEAN_OBJECTS = os.getenv("AV_SKIP_CLEAN_OBJECTS", "False")
+AV_SKIP_CLEAN_OBJECTS = int(os.getenv("AV_SKIP_CLEAN_OBJECTS", "0"))
 SNS_ENDPOINT = os.getenv("SNS_ENDPOINT", None)
 S3_ENDPOINT = os.getenv("S3_ENDPOINT", None)
 LAMBDA_ENDPOINT = os.getenv("LAMBDA_ENDPOINT", None)

--- a/scan.py
+++ b/scan.py
@@ -100,13 +100,6 @@ def verify_s3_object_version(s3, s3_object):
         )
 
 
-def is_clean(s3_object):
-    return (
-        str_to_bool(AV_SKIP_CLEAN_OBJECTS)
-        and s3_object.metadata.get(AV_STATUS_METADATA, None) == AV_STATUS_CLEAN
-    )
-
-
 def get_local_path(s3_object, local_prefix):
     return os.path.join(local_prefix, s3_object.bucket_name, s3_object.key)
 
@@ -219,7 +212,10 @@ def lambda_handler(event, context):
     print("Script starting at %s\n" % (start_time))
     s3_object = event_object(event, event_source=EVENT_SOURCE)
 
-    if is_clean(s3_object):
+    if (
+        AV_SKIP_CLEAN_OBJECTS
+        and s3_object.metadata.get(AV_STATUS_METADATA, None) == AV_STATUS_CLEAN
+    ):
         print("Object is clean, skipping...")
         return
 

--- a/scan.py
+++ b/scan.py
@@ -37,6 +37,7 @@ from common import AV_STATUS_SNS_ARN
 from common import AV_STATUS_SNS_PUBLISH_CLEAN
 from common import AV_STATUS_SNS_PUBLISH_INFECTED
 from common import AV_TIMESTAMP_METADATA
+from common import AV_SKIP_CLEAN_OBJECTS
 from common import SNS_ENDPOINT
 from common import S3_ENDPOINT
 from common import create_dir
@@ -97,6 +98,13 @@ def verify_s3_object_version(s3, s3_object):
         raise Exception(
             "Object versioning is not enabled in bucket %s" % s3_object.bucket_name
         )
+
+
+def is_clean(s3_object):
+    return (
+        str_to_bool(AV_SKIP_CLEAN_OBJECTS)
+        and s3_object.metadata.get(AV_STATUS_METADATA, None) == AV_STATUS_CLEAN
+    )
 
 
 def get_local_path(s3_object, local_prefix):
@@ -210,6 +218,10 @@ def lambda_handler(event, context):
     start_time = get_timestamp()
     print("Script starting at %s\n" % (start_time))
     s3_object = event_object(event, event_source=EVENT_SOURCE)
+
+    if is_clean(s3_object):
+        print("Object is clean, skipping...")
+        return
 
     if str_to_bool(AV_PROCESS_ORIGINAL_VERSION_ONLY):
         verify_s3_object_version(s3, s3_object)


### PR DESCRIPTION
This change adds a flag `AV_SKIP_CLEAN_OBJECTS` that allows us to skip objects that are guaranteed to be clean (i.e. server-generated files). This flag is disabled by default, so it won't disrupt any existing behavior.

If the flag is enabled, it will skip the scan for every file that has the metadata `av-status`: `CLEAN`.