### PR TITLE
add flag to skip objects marked as clean

### DIFF
--- a/common.py
+++ b/common.py
@@ -43,6 +43,7 @@ AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
 
 AV_DEFINITION_FILE_PREFIXES = ["main", "daily", "bytecode"]
 AV_DEFINITION_FILE_SUFFIXES = ["cld", "cvd"]
+AV_SKIP_CLEAN_OBJECTS = os.getenv("AV_SKIP_CLEAN_OBJECTS", "True")
 SNS_ENDPOINT = os.getenv("SNS_ENDPOINT", None)
 S3_ENDPOINT = os.getenv("S3_ENDPOINT", None)
 LAMBDA_ENDPOINT = os.getenv("LAMBDA_ENDPOINT", None)

--- a/scan.py
+++ b/scan.py
@@ -37,13 +37,14 @@ from common import AV_STATUS_SNS_ARN
 from common import AV_STATUS_SNS_PUBLISH_CLEAN
 from common import AV_STATUS_SNS_PUBLISH_INFECTED
 from common import AV_TIMESTAMP_METADATA
+from common import AV_SKIP_CLEAN_OBJECTS
 from common import SNS_ENDPOINT
 from common import S3_ENDPOINT
 from common import create_dir
 from common import get_timestamp
 
 
-def event_object(event, event_source="s3"):
+def s3_object_from_event(event, event_source="s3"):
     # SNS events are slightly different
     if event_source.upper() == "SNS":
         event = json.loads(event["Records"][0]["Sns"]["Message"])
@@ -73,7 +74,6 @@ def event_object(event, event_source="s3"):
     if (not bucket_name) or (not key_name):
         raise Exception("Unable to retrieve object from event.\n{}".format(event))
 
-    # Create and return the object
     s3 = boto3.resource("s3", endpoint_url=S3_ENDPOINT)
     return s3.Object(bucket_name, key_name)
 
@@ -209,7 +209,11 @@ def lambda_handler(event, context):
 
     start_time = get_timestamp()
     print("Script starting at %s\n" % (start_time))
-    s3_object = event_object(event, event_source=EVENT_SOURCE)
+    s3_object = s3_object_from_event(event, EVENT_SOURCE)
+
+    if skip_when_clean_metadata(s3_object, AV_SKIP_CLEAN_OBJECTS):
+        print("Object marked as clean with metadata, skipping...")
+        return
 
     if str_to_bool(AV_PROCESS_ORIGINAL_VERSION_ONLY):
         verify_s3_object_version(s3, s3_object)
@@ -272,3 +276,12 @@ def lambda_handler(event, context):
 
 def str_to_bool(s):
     return bool(strtobool(str(s)))
+
+
+def skip_when_clean_metadata(s3_object, av_skip_clean_objects):
+    if str_to_bool(av_skip_clean_objects) and (
+        s3_object.metadata.get(AV_STATUS_METADATA, None) == AV_STATUS_CLEAN
+    ):
+        return True
+
+    return False

--- a/scan_test.py
+++ b/scan_test.py
@@ -25,16 +25,18 @@ from common import AV_SCAN_START_METADATA
 from common import AV_SIGNATURE_METADATA
 from common import AV_SIGNATURE_OK
 from common import AV_STATUS_METADATA
+from common import AV_STATUS_CLEAN
 from common import AV_TIMESTAMP_METADATA
 from common import get_timestamp
 from scan import delete_s3_object
-from scan import event_object
+from scan import s3_object_from_event
 from scan import get_local_path
 from scan import set_av_metadata
 from scan import set_av_tags
 from scan import sns_start_scan
 from scan import sns_scan_results
 from scan import verify_s3_object_version
+from scan import skip_when_clean_metadata
 
 
 class TestScan(unittest.TestCase):
@@ -62,7 +64,7 @@ class TestScan(unittest.TestCase):
             ]
         }
         sns_event = {"Records": [{"Sns": {"Message": json.dumps(event)}}]}
-        s3_obj = event_object(sns_event, event_source="sns")
+        s3_obj = s3_object_from_event(sns_event, event_source="sns")
         expected_s3_object = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
         self.assertEquals(s3_obj, expected_s3_object)
 
@@ -77,26 +79,26 @@ class TestScan(unittest.TestCase):
                 }
             ]
         }
-        s3_obj = event_object(event)
+        s3_obj = s3_object_from_event(event)
         expected_s3_object = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
         self.assertEquals(s3_obj, expected_s3_object)
 
     def test_s3_event_object_missing_bucket(self):
         event = {"Records": [{"s3": {"object": {"key": self.s3_key_name}}}]}
         with self.assertRaises(Exception) as cm:
-            event_object(event)
+            s3_object_from_event(event)
             self.assertEquals(cm.exception.message, "No bucket found in event!")
 
     def test_s3_event_object_missing_key(self):
         event = {"Records": [{"s3": {"bucket": {"name": self.s3_bucket_name}}}]}
         with self.assertRaises(Exception) as cm:
-            event_object(event)
+            s3_object_from_event(event)
             self.assertEquals(cm.exception.message, "No key found in event!")
 
     def test_s3_event_object_bucket_key_missing(self):
         event = {"Records": [{"s3": {"bucket": {}, "object": {}}}]}
         with self.assertRaises(Exception) as cm:
-            event_object(event)
+            s3_object_from_event(event)
             self.assertEquals(
                 cm.exception.message,
                 "Unable to retrieve object from event.\n{}".format(event),
@@ -105,8 +107,43 @@ class TestScan(unittest.TestCase):
     def test_s3_event_object_no_records(self):
         event = {"Records": []}
         with self.assertRaises(Exception) as cm:
-            event_object(event)
+            s3_object_from_event(event)
             self.assertEquals(cm.exception.message, "No records found in event!")
+
+    def test_skip_when_clean_metadata_without_clean_status(self):
+        s3_obj = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
+        s3_stubber_resource = Stubber(self.s3.meta.client)
+
+        head_object_response = {"ContentType": "content", "Metadata": {}}
+        head_object_expected_params = {
+            "Bucket": self.s3_bucket_name,
+            "Key": self.s3_key_name,
+        }
+        s3_stubber_resource.add_response(
+            "head_object", head_object_response, head_object_expected_params
+        )
+        with s3_stubber_resource:
+            self.assertFalse(skip_when_clean_metadata(s3_obj, "True"))
+            self.assertFalse(skip_when_clean_metadata(s3_obj, "False"))
+
+    def test_skip_when_clean_metadata_with_clean_status(self):
+        s3_obj = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
+        s3_stubber_resource = Stubber(self.s3.meta.client)
+
+        head_object_response = {
+            "ContentType": "content",
+            "Metadata": {AV_STATUS_METADATA: AV_STATUS_CLEAN},
+        }
+        head_object_expected_params = {
+            "Bucket": self.s3_bucket_name,
+            "Key": self.s3_key_name,
+        }
+        s3_stubber_resource.add_response(
+            "head_object", head_object_response, head_object_expected_params
+        )
+        with s3_stubber_resource:
+            self.assertTrue(skip_when_clean_metadata(s3_obj, "True"))
+            self.assertFalse(skip_when_clean_metadata(s3_obj, "False"))
 
     def test_verify_s3_object_version(self):
         s3_obj = self.s3.Object(self.s3_bucket_name, self.s3_key_name)


### PR DESCRIPTION
Changes proposed in this pull request:

- Inspired by [PR#11](https://github.com/trussworks/bucket-antivirus-function/pull/11)
- Add environment variable `AV_SKIP_CLEAN_OBJECTS` (default: `True`)
- Rename the function `event_object` to `s3_object_from_event` to better reflect its purpose
- Added tests to cover the proposed change